### PR TITLE
Reduce minimum SDK to 16.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.xhbtech.speechapp"
-        minSdkVersion 19
+        minSdkVersion 16
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/com/xhbtech/speechapp/MainActivity.java
+++ b/app/src/main/java/com/xhbtech/speechapp/MainActivity.java
@@ -44,7 +44,7 @@ public class MainActivity extends AppCompatActivity {
                     if (result == TextToSpeech.LANG_MISSING_DATA ||
                             result == TextToSpeech.LANG_NOT_SUPPORTED) {
                         Toast.makeText(getApplicationContext(), "This language is not supported!",
-                                Toast.LENGTH_SHORT);
+                                Toast.LENGTH_SHORT).show();
                     } else {
                         toSpeech.setPitch(0.6f);
                         toSpeech.setSpeechRate(1.0f);


### PR DESCRIPTION
The app can easily be targeting API 16 (Jelly bean) instead of 19, and therefore work on an even wider range of devices.
This also fixes a Toast that would never be shown without calling the `show()` method.